### PR TITLE
feat: #49 로그인 유저 상태 관리 & 헤더에 적용

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,10 +4,10 @@ import MyPage from '@/pages/MyPage/MyPage.jsx';
 import MainHeader from './layouts/MainHeader';
 import Cart from './pages/cart/Cart';
 import Detail from './pages/Detail';
-import Main from './pages/main/Main';
-import Payment from './pages/payment/Payment';
 import Join from './pages/Join/Join';
 import Login from './pages/Login/Login';
+import Main from './pages/main/Main';
+import Payment from './pages/payment/Payment';
 import Write from './pages/Write/Write';
 
 function App() {

--- a/src/layouts/HeaderRightBox.jsx
+++ b/src/layouts/HeaderRightBox.jsx
@@ -1,17 +1,30 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 
 import { Icon } from '@/components/common/Icon/Icon.jsx';
 import { itemListState } from '@/recoil/atoms/itemListState.js';
+import { userState } from '@/recoil/atoms/userState.js';
 import * as S from './Header.Styles.jsx';
 
 const HeaderRightBox = () => {
-  let isCustomer = false;
-  let isLogin = true;
+  // 상태관리 추가를 위해 주석처리했습니다. 확인 후 삭제예정
+  // let isCustomer = false;
+  // let isLogin = true;
+
+  // recoil의 상태 정보 불러오기
+  const getUser = useRecoilValue(userState);
 
   const [isSearchBar, setIsSearchBar] = useState(false);
   const [searchFilter, setSearchFilter] = useRecoilState(itemListState);
+  // 로그인 유무 확인 상태관리 추가
+  const [isLogin, setIsLogin] = useState(false);
+  const [isCustomer, setIsCustomer] = useState(false);
+
+  useEffect(() => {
+    getUser.email !== '' ? setIsLogin(true) : setIsLogin(false);
+    getUser.role === 'CONSUMER' ? setIsCustomer(true) : setIsCustomer(false);
+  }, [getUser.email, getUser.role]);
 
   const searchBarHandler = () => {
     if (!isSearchBar) setIsSearchBar(true);

--- a/src/layouts/HeaderRightBox.jsx
+++ b/src/layouts/HeaderRightBox.jsx
@@ -1,30 +1,20 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilState } from 'recoil';
 
 import { Icon } from '@/components/common/Icon/Icon.jsx';
 import { itemListState } from '@/recoil/atoms/itemListState.js';
-import { userState } from '@/recoil/atoms/userState.js';
+import { customerState, loginState } from '@/recoil/atoms/userState.js';
 import * as S from './Header.Styles.jsx';
 
 const HeaderRightBox = () => {
-  // 상태관리 추가를 위해 주석처리했습니다. 확인 후 삭제예정
-  // let isCustomer = false;
-  // let isLogin = true;
-
   // recoil의 상태 정보 불러오기
-  const getUser = useRecoilValue(userState);
+  // const getUser = useRecoilValue(userState);
+  const [isLogin, setIsLogin] = useRecoilState(loginState);
+  const [isCustomer, setIsCustomer] = useRecoilState(customerState);
 
   const [isSearchBar, setIsSearchBar] = useState(false);
   const [searchFilter, setSearchFilter] = useRecoilState(itemListState);
-  // 로그인 유무 확인 상태관리 추가
-  const [isLogin, setIsLogin] = useState(false);
-  const [isCustomer, setIsCustomer] = useState(false);
-
-  useEffect(() => {
-    getUser.email !== '' ? setIsLogin(true) : setIsLogin(false);
-    getUser.role === 'CONSUMER' ? setIsCustomer(true) : setIsCustomer(false);
-  }, [getUser.email, getUser.role]);
 
   const searchBarHandler = () => {
     if (!isSearchBar) setIsSearchBar(true);

--- a/src/pages/Login/Login.jsx
+++ b/src/pages/Login/Login.jsx
@@ -1,21 +1,26 @@
 import { Link, useNavigate } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
 
 import { login } from '@/apis/user.js';
 import UserInput from '@/components/common/UserInput/UserInput';
 import { localstorageKey } from '@/constant/index.js';
 import { useInputs } from '@/hooks/useInputs.js';
 import HeaderLogo from '@/layouts/HeaderLogo';
+import { userState } from '@/recoil/atoms/userState';
 import { theme } from '@/styles/theme';
 import { saveItem } from '@/utils/localstorage.js';
 import * as S from './Login.styles';
 
 const Login = () => {
   const navigate = useNavigate();
+  // recoil 선언
+  const setUser = useSetRecoilState(userState);
 
   // TODO: 실제 서비스할 때는 제거! (매번 입력하기 싫어서 입력)
+  // 초기값 빈 string으로 변경했습니다. -> 동영
   const { value: loginForm, onChange } = useInputs({
-    email: 'admin@gmail.com',
-    password: 'admin1234',
+    email: '',
+    password: '',
   });
 
   const linkToKakaoLogin = (e) => {
@@ -32,10 +37,19 @@ const Login = () => {
       password: loginForm.password,
     }).then((result) => {
       // TODO: 로그인 성공 후 localstorage 에 값가져오기 및 전역 상태로 상태 추가
+      console.log(result);
       if (result.status === 200) {
+        // recoil 사용
+        setUser({
+          email: result.data.email,
+          role: result.data.role,
+          profileUrl: result.data.profileUrl,
+        });
         saveItem(localstorageKey.auth, result.data.token);
         // TODO: user 를 전역 상태로 관리하면 해당 부분 삭제
-        saveItem(localstorageKey.user, result.data);
+        // user 전역 상태 관리 추가로 주석처리했습니다. 확인 후 삭제 예정 -> 동영
+        // saveItem(localstorageKey.user, result.data);
+
         navigate('/');
       }
     });
@@ -56,7 +70,7 @@ const Login = () => {
         <UserInput
           type="password"
           required
-          placeholder="passowrd"
+          placeholder="password"
           name="password"
           value={loginForm.password}
           onChange={onChange}

--- a/src/recoil/atoms/userState.js
+++ b/src/recoil/atoms/userState.js
@@ -1,0 +1,14 @@
+import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
+
+const { persistAtom } = recoilPersist();
+
+export const userState = atom({
+  key: 'userState',
+  default: {
+    email: '',
+    role: '',
+    profileUrl: '',
+  },
+  effects_UNSTABLE: [persistAtom],
+});

--- a/src/recoil/atoms/userState.js
+++ b/src/recoil/atoms/userState.js
@@ -1,4 +1,4 @@
-import { atom } from 'recoil';
+import { atom, selector } from 'recoil';
 import { recoilPersist } from 'recoil-persist';
 
 const { persistAtom } = recoilPersist();
@@ -11,4 +11,14 @@ export const userState = atom({
     profileUrl: '',
   },
   effects_UNSTABLE: [persistAtom],
+});
+
+export const loginState = selector({
+  key: 'loginState',
+  get: ({ get }) => (get(userState).email !== '' ? true : false),
+});
+
+export const customerState = selector({
+  key: 'customerState',
+  get: ({ get }) => get(userState).role === 'CONSUMER',
 });


### PR DESCRIPTION
closed #49 

## 💡 개요
![image](https://github.com/supercoding-project-week02/shopping-mall-front-end/assets/112530541/bafb73bb-6fcc-4ba0-a80f-28b24fd4e15a)


## 📝 작업 내용
- recoil 을 사용해서 로그인 유지 ( 새로고침시에도 유지 가능)
- 헤더에 recoil 상태관리를 통하여 유저정보 파악 후 상태 추가
- 로그인 시 토큰과 유저정보가 따로 로컬스토리지에 저장됩니다.
- 유저 정보에는 email, role(판매자,구매자), 프로필이미지url이 들어있습니다

## ‼️ 주의 사항
- 현재 로그아웃 버튼이 없어서 로그아웃하려면 로컬스토리지에 저장되어 있는 값들을 삭제해야 됩니다.

## 🔗 참고자료
<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->
