### PR TITLE
feat: #73 카카오 로그인 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import MainHeader from './layouts/MainHeader';
 import Cart from './pages/cart/Cart';
 import Detail from './pages/Detail/Detail';
 import Join from './pages/Join/Join';
+import Kakao from './pages/Kakao';
 import Login from './pages/Login/Login';
 import Main from './pages/main/Main';
 import Payment from './pages/payment/Payment';
@@ -53,6 +54,10 @@ function App() {
         {
           path: 'login',
           element: <Login />,
+        },
+        {
+          path: 'auth/kakao',
+          element: <Kakao />,
         },
       ],
     },

--- a/src/apis/user.js
+++ b/src/apis/user.js
@@ -24,3 +24,8 @@ export const changeAddress = async (payload) => {
   const response = await client.post('/user/address', payload);
   return response.data;
 };
+
+export const kakaoLogin = async (payload) => {
+  const response = await client.post('/user/kakao', payload);
+  return response.data;
+};

--- a/src/pages/Kakao.jsx
+++ b/src/pages/Kakao.jsx
@@ -1,0 +1,45 @@
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
+import styled from '@emotion/styled';
+
+import { kakaoLogin } from '@/apis/user';
+import { LoadingSpinner } from '@/components/common/LoadingSpinner/LoadingSpinner';
+import { localstorageKey } from '@/constant';
+import { userState } from '@/recoil/atoms/userState';
+import { saveItem } from '@/utils/localstorage';
+
+const Kakao = () => {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const setUser = useSetRecoilState(userState);
+  const code = searchParams.get('code');
+
+  kakaoLogin({
+    code: code,
+  }).then((result) => {
+    console.log(result);
+    if (result.status === 200) {
+      setUser({
+        email: result.data.email,
+        role: result.data.role,
+        profileUrl: result.data.profileUrl,
+      });
+      saveItem(localstorageKey.auth, result.data.token);
+
+      alert('카카오로 로그인 되었습니다.');
+      navigate('/');
+    }
+  });
+  return (
+    <KakoContainer>
+      <LoadingSpinner isFullWidth size={50} />
+    </KakoContainer>
+  );
+};
+
+export default Kakao;
+
+const KakoContainer = styled.div`
+  width: 100%;
+  height: 300px;
+`;

--- a/src/pages/Kakao.jsx
+++ b/src/pages/Kakao.jsx
@@ -1,4 +1,4 @@
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
 import styled from '@emotion/styled';
 
@@ -9,7 +9,6 @@ import { userState } from '@/recoil/atoms/userState';
 import { saveItem } from '@/utils/localstorage';
 
 const Kakao = () => {
-  const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const setUser = useSetRecoilState(userState);
   const code = searchParams.get('code');
@@ -26,8 +25,7 @@ const Kakao = () => {
       });
       saveItem(localstorageKey.auth, result.data.token);
 
-      alert('카카오로 로그인 되었습니다.');
-      navigate('/');
+      location.href = '/';
     }
   });
   return (

--- a/src/pages/Login/Login.jsx
+++ b/src/pages/Login/Login.jsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
 
 import { login } from '@/apis/user.js';
@@ -12,7 +12,6 @@ import { saveItem } from '@/utils/localstorage.js';
 import * as S from './Login.styles';
 
 const Login = () => {
-  const navigate = useNavigate();
   // recoil 선언
   const setUser = useSetRecoilState(userState);
 
@@ -50,8 +49,7 @@ const Login = () => {
         // user 전역 상태 관리 추가로 주석처리했습니다. 확인 후 삭제 예정 -> 동영
         // saveItem(localstorageKey.user, result.data);
 
-        alert('로그인 되었습니다.');
-        navigate('/');
+        location.href = '/';
       }
     });
   };

--- a/src/pages/Login/Login.jsx
+++ b/src/pages/Login/Login.jsx
@@ -25,7 +25,7 @@ const Login = () => {
 
   const linkToKakaoLogin = (e) => {
     e.preventDefault();
-    console.log('kakao로그인');
+    window.location.href = `https://kauth.kakao.com/oauth/authorize?client_id=39e024cd16a47a29d9162ee86e85b69a&redirect_uri=http://localhost:5173/auth/kakao&response_type=code`;
   };
 
   const handleLogin = (e) => {
@@ -50,6 +50,7 @@ const Login = () => {
         // user 전역 상태 관리 추가로 주석처리했습니다. 확인 후 삭제 예정 -> 동영
         // saveItem(localstorageKey.user, result.data);
 
+        alert('로그인 되었습니다.');
         navigate('/');
       }
     });


### PR DESCRIPTION
closed #73 

## 💡 개요
- 카카오 소셜 로그인 구현

## 📝 작업 내용
- 카카오 버튼 클릭 시 인가코드 받아옴
- 인가코드를 백엔드에 전달 후 로그인 처리
- 응답받은 회원정보를 전역상태로 추가 후 메인페이지로 이동

## ‼️ 주의 사항
<!-- 해당 작업에서 주의해아할 사항  -->

## 🔗 참고자료
<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->
